### PR TITLE
Include joyn switzerland in rule

### DIFF
--- a/filters/filters.txt
+++ b/filters/filters.txt
@@ -7963,7 +7963,7 @@ pornult.com##.sexshp
 ! https://github.com/NanoMeow/QuickReports/issues/1406
 ! https://github.com/NanoMeow/QuickReports/issues/3929
 ! https://github.com/uBlockOrigin/uAssets/issues/23986
-joyn.de,joyn.at##+js(no-fetch-if, zomap.de)
+joyn.de,joyn.at,joyn.ch##+js(no-fetch-if, zomap.de)
 @@||ad.71i.de/global_js/AppConfig/Joyn/desktop.json$xhr,domain=joyn.de
 @@||adition.com/1x1.gif$xhr,domain=joyn.de
 @@||aws.route71.net/ad-$script,domain=joyn.de


### PR DESCRIPTION
On joyn.ch adds are playing. Adding this rule fixes this.

### URL(s) where the issue occurs

`https://www.joyn.ch/play/serien/schlag-den-star/2025-5-das-schwesternduell-luna-und-lilli-schweiger-vs-shania-und-davina-geiss`

### Describe the issue

Ads are playing on the SWISS version of the size (not on .de)

### Screenshot(s)

Not applicable

### Versions

- Browser/version: Firefox Desktop 139.0 (Ubuntu)
- uBlock Origin version: 1.64

### Settings

- Only the one change that fixes the issue which I included in this pull request

### Notes

None :)
